### PR TITLE
Add python3-dev to fix Bookworm compatibility

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="python3-cryptography python3-pycurl python3-venv libcurl4-openssl-dev libssl-dev"
+pkg_dependencies="python3-cryptography python3-pycurl python3-venv libcurl4-openssl-dev libssl-dev python3-dev"
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
## Problem

- Fails to install on `bookworm` https://dash.yunohost.org/appci/app/pyload

## Solution

- Added missing `python3-dev` dependency

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
